### PR TITLE
Fix bug in overlay when dock pane has siblings

### DIFF
--- a/src/main/java/org/dockfx/DockPane.java
+++ b/src/main/java/org/dockfx/DockPane.java
@@ -545,12 +545,10 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
   public void handle(DockEvent event) {
     if (event.getEventType() == DockEvent.DOCK_ENTER) {
       if (!dockIndicatorOverlay.isShowing()) {
-        Bounds bounds = DockPane.this.getBoundsInParent();
-        Bounds localBounds = DockPane.this.getBoundsInLocal();
-        Bounds screenBounds = DockPane.this.localToScreen(localBounds);
+        Point2D originToScreen = root.localToScreen(0, 0);
 
         dockIndicatorOverlay
-            .show(DockPane.this, screenBounds.getMinX(), screenBounds.getMinY() - bounds.getMinY());
+            .show(DockPane.this, originToScreen.getX(), originToScreen.getY());
       }
     } else if (event.getEventType() == DockEvent.DOCK_OVER) {
       this.receivedEnter = false;
@@ -573,10 +571,11 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
       }
 
       if (dockPosDrag != null && dockAreaDrag != null) {
-        Point2D originToScene = dockAreaDrag.localToScene(0, 0);
+        Point2D originToScene = dockAreaDrag.localToScreen(0, 0);
 
         dockAreaIndicator.setVisible(true);
-        dockAreaIndicator.relocate(originToScene.getX(), originToScene.getY());
+        dockAreaIndicator.relocate(originToScene.getX() - dockIndicatorOverlay.getAnchorX(),
+                originToScene.getY() - dockIndicatorOverlay.getAnchorY());
         if (dockPosDrag == DockPos.RIGHT) {
           dockAreaIndicator.setTranslateX(dockAreaDrag.getLayoutBounds().getWidth() / 2);
         } else {

--- a/src/main/java/org/dockfx/demo/DockFX.java
+++ b/src/main/java/org/dockfx/demo/DockFX.java
@@ -49,6 +49,7 @@ import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.AnchorPane;
 import javafx.scene.web.HTMLEditor;
 import javafx.stage.Stage;
 
@@ -131,7 +132,10 @@ public class DockFX extends Application {
     BorderPane mainBorderPane = new BorderPane();
     mainBorderPane.setTop(menuBar);
     mainBorderPane.setCenter(dockPane);
-
+    
+    // show that overlays are relative to the docking area
+    mainBorderPane.setLeft(new AnchorPane(generateRandomTree()));
+    
     primaryStage.setScene(new Scene(mainBorderPane, 800, 500));
     primaryStage.sizeToScene();
 


### PR DESCRIPTION
When the dock pane has siblings, for example there are Top/Left panes in a boarder pane (see example) the calculation of the overlay does not take these into account.

This patch fixes that issue and includes a small change to the demo to illustrate the problem.