### PR TITLE
Exclusive Mode

### DIFF
--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.tab-size>4</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.tab-size>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>true</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.continuationIndentSize>4</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.continuationIndentSize>
+    </properties>
+</project-shared-configuration>

--- a/src/main/java/org/dockfx/DockPane.java
+++ b/src/main/java/org/dockfx/DockPane.java
@@ -24,25 +24,16 @@ import java.beans.XMLDecoder;
 import java.beans.XMLEncoder;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Scanner;
 import java.util.Stack;
-import java.util.TreeMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.sun.javafx.css.StyleManager;
 
-import javafx.geometry.Bounds;
-import javafx.scene.control.Tab;
 import javafx.stage.Stage;
 
 import org.dockfx.pane.ContentPane;
@@ -524,10 +515,16 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
         ContentPane pane = (ContentPane) parent;
         pane.removeNode(findStack, node);
 
-        // if there is only 1-tab left, we replace it with the SplitPane
-        if (pane.getChildrenList().size() == 1 &&
+        // if there is 0 children left, make sure we remove the split pane
+        if (pane.getChildrenList().isEmpty()) {
+          if (root == pane) {
+            this.getChildren().remove((Node) pane);
+            root = null;
+          }
+        } else if (pane.getChildrenList().size() == 1 &&
             pane instanceof ContentTabPane &&
             pane.getChildrenList().get(0) instanceof DockNode) {
+          // if there is only 1-tab left, we replace it with the SplitPane
 
           List<Node> children = pane.getChildrenList();
           Node sibling = children.get(0);
@@ -545,8 +542,14 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
   public void handle(DockEvent event) {
     if (event.getEventType() == DockEvent.DOCK_ENTER) {
       if (!dockIndicatorOverlay.isShowing()) {
-        Point2D originToScreen = root.localToScreen(0, 0);
-
+        Point2D originToScreen;
+        if (null != root) {
+            originToScreen = root.localToScreen(0, 0);
+        }
+        else {
+            originToScreen = this.localToScreen(0, 0);
+        }
+        
         dockIndicatorOverlay
             .show(DockPane.this, originToScreen.getX(), originToScreen.getY());
       }

--- a/src/main/java/org/dockfx/DockPane.java
+++ b/src/main/java/org/dockfx/DockPane.java
@@ -821,7 +821,7 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
         node = delayOpenHandler.open(title);
 
       if(null != node) {
-        node.setFloating(true, null);
+        node.setFloating(true, null, this);
 
         node.getStage().setX(position[0]);
         node.getStage().setY(position[1]);

--- a/src/main/java/org/dockfx/DockPane.java
+++ b/src/main/java/org/dockfx/DockPane.java
@@ -74,6 +74,12 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
    * The current root node of this dock pane's layout.
    */
   private Node root;
+  
+  /** 
+   * Whether or not this dock pane allows the docking of dock nodes from 
+   * external sources (i.e., other dock panes).
+   */
+  private boolean exclusive = false;
 
   /**
    * Whether a DOCK_ENTER event has been received by this dock pane since the last DOCK_EXIT event
@@ -296,6 +302,25 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
     dockAreaIndicator.getStyleClass().add("dock-area-indicator");
 
     undockedNodes = FXCollections.observableArrayList();
+  }
+
+  /**
+   * Indicates whether or not the dock pane is in exclusive mode (the 
+   * default).  In exclusive mode, the dock pane ignores dock nodes 
+   * dragged from other dock panes, and dock nodes dragged from this dock pane
+   * are ignored by other dock panes.
+   * @return true or false. 
+   */
+  public boolean isExclusive() {
+    return exclusive;
+  }
+
+  /**
+   * Enables/disables exclusive mode.
+   * @param exclusive true for exclusive mode, and false otherwise.
+   */
+  public void setExclusive(boolean exclusive) {
+    this.exclusive = exclusive;
   }
 
   /**
@@ -540,6 +565,21 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
 
   @Override
   public void handle(DockEvent event) {
+    // handle exclusive mode.
+    DockPane otherPane = ((DockNode)event.getContents()).getDockPane();
+
+    if (otherPane != this) {
+      if (isExclusive()) {
+        // Can't accept nodes from other dock panes.
+        return;
+      }
+
+      if (otherPane != null && otherPane.isExclusive()) {
+        // Nodes from the other pane cannot be docked elsewhere.
+        return;
+      }
+    }
+        
     if (event.getEventType() == DockEvent.DOCK_ENTER) {
       if (!dockIndicatorOverlay.isShowing()) {
         Point2D originToScreen;

--- a/src/main/java/org/dockfx/DockTitleBar.java
+++ b/src/main/java/org/dockfx/DockTitleBar.java
@@ -321,7 +321,7 @@ public class DockTitleBar extends HBox implements EventHandler<MouseEvent> {
         // then we need to offset the stage position by
         // the height of this title bar
         if (!dockNode.isCustomTitleBar() && dockNode.isDecorated()) {
-          dockNode.setFloating(true, new Point2D(0, DockTitleBar.this.getHeight()));
+          dockNode.setFloating(true, new Point2D(0, DockTitleBar.this.getHeight()), null);
         } else {
           dockNode.setFloating(true);
         }
@@ -373,6 +373,12 @@ public class DockTitleBar extends HBox implements EventHandler<MouseEvent> {
       Stage stage = dockNode.getStage();
       Insets insetsDelta = this.getDockNode().getBorderPane().getInsets();
 
+      // it is possible that drag start has not been set if some other node had focus when
+      // we started the drag
+      if (null == dragStart) {
+        dragStart = new Point2D(event.getX(), event.getY());
+      }
+      
       // dragging this way makes the interface more responsive in the event
       // the system is lagging as is the case with most current JavaFX
       // implementations on Linux

--- a/src/main/java/org/dockfx/DockTitleBar.java
+++ b/src/main/java/org/dockfx/DockTitleBar.java
@@ -388,13 +388,13 @@ public class DockTitleBar extends HBox implements EventHandler<MouseEvent> {
       // TODO: change the pick result by adding a copyForPick()
       DockEvent dockEnterEvent =
           new DockEvent(this, DockEvent.NULL_SOURCE_TARGET, DockEvent.DOCK_ENTER, event.getX(),
-              event.getY(), event.getScreenX(), event.getScreenY(), null);
+              event.getY(), event.getScreenX(), event.getScreenY(), null, this.getDockNode());
       DockEvent dockOverEvent =
           new DockEvent(this, DockEvent.NULL_SOURCE_TARGET, DockEvent.DOCK_OVER, event.getX(),
-              event.getY(), event.getScreenX(), event.getScreenY(), null);
+              event.getY(), event.getScreenX(), event.getScreenY(), null, this.getDockNode());
       DockEvent dockExitEvent =
           new DockEvent(this, DockEvent.NULL_SOURCE_TARGET, DockEvent.DOCK_EXIT, event.getX(),
-              event.getY(), event.getScreenX(), event.getScreenY(), null);
+              event.getY(), event.getScreenX(), event.getScreenY(), null, this.getDockNode());
 
       EventTask eventTask = new EventTask() {
         @Override

--- a/src/main/java/org/dockfx/demo/TwoDockPanes.java
+++ b/src/main/java/org/dockfx/demo/TwoDockPanes.java
@@ -1,0 +1,113 @@
+/**
+ * @file DockFX.java
+ * @brief Driver demonstrating basic dock layout with prototypes. Maintained in a separate package
+ *        to ensure the encapsulation of org.dockfx private package members.
+ *
+ * @section License
+ *
+ *          This file is a part of the DockFX Library. Copyright (C) 2015 Robert B. Colton
+ *
+ *          This program is free software: you can redistribute it and/or modify it under the terms
+ *          of the GNU Lesser General Public License as published by the Free Software Foundation,
+ *          either version 3 of the License, or (at your option) any later version.
+ *
+ *          This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *          WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *          PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ *          You should have received a copy of the GNU Lesser General Public License along with this
+ *          program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+package org.dockfx.demo;
+
+
+import org.dockfx.DockPane;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.ToolBar;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.dockfx.DockNode;
+import org.dockfx.DockPos;
+
+/**
+ * This app creates two dock panes, one over the other. Nodes can be added to either.
+ * If dock pane A is "exclusive", then A will ignore nodes from B (because A is 
+ * exclusive and won't accept nodes from any other dockpane, and B will ignore nodes
+ * from A because A is exclusive and won't let go of them.
+ * 
+ * If neither A or B is exclusive, Issue #24 from RobertBColton/DockFX will occur. 
+ * @author will
+ */
+public class TwoDockPanes extends Application {
+
+  public static void main(String[] args) {
+    launch(args);
+  }
+
+  private VBox vbox;
+  private DockPane dp1;
+  private DockPane dp2;
+  private int counter = 0;
+  private final Image dockImage = 
+    new Image(DockFX.class.getResource("docknode.png").toExternalForm());
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void start(Stage primaryStage) {
+    primaryStage.setTitle("DockFX");
+   
+    vbox = new VBox();
+
+    dp1 = makeDockPane("A");
+    dp2 = makeDockPane("B");
+
+    dp1.setExclusive(true);
+    
+
+    primaryStage.setScene(new Scene(vbox, 800, 500));
+    primaryStage.sizeToScene();
+    primaryStage.show();
+
+    // test the look and feel with both Caspian and Modena
+    Application.setUserAgentStylesheet(Application.STYLESHEET_MODENA);
+    DockPane.initializeDefaultUserAgentStylesheet();
+  }
+
+  private DockPane makeDockPane(String name) {
+    ToolBar bar = new ToolBar();
+    Label lab = new Label(name);
+    Button addButton = new Button("Add");
+    bar.getItems().add(lab);
+    bar.getItems().add(addButton);
+
+    DockPane dp = new DockPane();
+    VBox.setVgrow(dp, Priority.ALWAYS);
+
+    addButton.setOnAction(evt -> addNode(dp, name));
+
+    vbox.getChildren().add(bar);
+    vbox.getChildren().add(dp);
+
+    return dp;
+  }
+
+  private void addNode(DockPane dp, String dockName) {
+    int n = ++counter;
+    String title = dockName + "Node " + counter;
+    TextArea ta = new TextArea();
+    ta.setText(title + "\n\nJust some test data"); 
+    DockNode dn = new DockNode(ta, title, new ImageView(dockImage));
+    dn.dock(dp, DockPos.BOTTOM);
+  }
+
+
+}

--- a/src/main/java/org/dockfx/pane/ContentSplitPane.java
+++ b/src/main/java/org/dockfx/pane/ContentSplitPane.java
@@ -182,7 +182,7 @@ public class ContentSplitPane extends SplitPane implements ContentPane {
 
   @Override
   protected double computeMaxWidth(double height) {
-        if (getOrientation() == Orientation.VERTICAL) {
+        if ((getOrientation() == Orientation.VERTICAL) && (!getItems().isEmpty())) {
             return getItems().stream().map(i -> i.maxWidth(height)).min(Comparator.naturalOrder()).get();
         }
         


### PR DESCRIPTION
In exclusive DockPane mode, a DockPane will not accept DockNodes dragged from some other DockPane. Further, no DockPane will accept DockNodes dragged from an exclusive DockPane. Exclusivity is implemented in DockPane.handle(), and so limits only the user's actions.