### PR TITLE
Hover over null dock

### DIFF
--- a/src/main/java/org/dockfx/DockNode.java
+++ b/src/main/java/org/dockfx/DockNode.java
@@ -268,12 +268,18 @@ public class DockNode extends VBox implements EventHandler<MouseEvent> {
     this.contents = contents;
     this.viewController = controller;
 
-    dockTitleBar = new DockTitleBar(this);
+    if (title != null) {
+        dockTitleBar = new DockTitleBar(this);
+        getChildren().addAll(dockTitleBar, contents);
+    } else {
+        dockTitleBar = null;
+        getChildren().addAll(contents);
+    }
+
     if (viewController != null) {
       viewController.setDockTitleBar(dockTitleBar);
     }
 
-    getChildren().addAll(dockTitleBar, contents);
     VBox.setVgrow(contents, Priority.ALWAYS);
 
     this.getStyleClass().add("dock-node");

--- a/src/main/java/org/dockfx/DockPane.java
+++ b/src/main/java/org/dockfx/DockPane.java
@@ -679,7 +679,7 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
         dockAreaIndicator.setVisible(false);
       }
 
-      if (dockNodeDrag != null) {
+      if (dockNodeDrag != null && ((DockNode)dockNodeDrag).getDockTitleBar() != null) {
         Point2D originToScreen = dockNodeDrag.localToScreen(0, 0);
 
         double posX = originToScreen.getX() + dockNodeDrag.getLayoutBounds().getWidth() / 2

--- a/src/main/java/org/dockfx/DockPane.java
+++ b/src/main/java/org/dockfx/DockPane.java
@@ -337,7 +337,7 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
    *
    * @return The URL of the default style sheet used by DockFX.
    */
-  public final static String getDefaultUserAgentStyleheet() {
+  public final static String getDefaultUserAgentStylesheet() {
     return DockPane.class.getResource("default.css").toExternalForm();
   }
 


### PR DESCRIPTION
The problem: when creating a DockNode with a null DockTitleBar, you can still drag and drop another node on top of it.  The result is you get a skinny tab representing that DockNode, with no text, no icon, just a skinny tab.  See my [post on Stackoverflow](http://stackoverflow.com/questions/42355893/javafx-docking-systems-how-to-make-undraggable-node-with-desired-behavior) for an image.

The desired behavior: If the DockNode has a null DockTitleBar, then you should not be able to drag anything on top.

The solution: Qualify DockPositionIndicator code with whether the node has a null DockTitleBar.  Now the DockPosition circle does not appear when you attempt to drop a DockNode on top of another DockNode with a null DockTitleBar..

Other issues: I wanted to be able to call DockNode with a null for the title String, instead of having to call setDockTitleBar later on with a null argument, so i changed that.  I also found a minor typo.
