### PR TITLE
changes to support <DockPane> and <DockNode> in .fxml files

### DIFF
--- a/src/main/java/org/dockfx/DockNode.java
+++ b/src/main/java/org/dockfx/DockNode.java
@@ -292,6 +292,10 @@ public class DockNode extends VBox implements EventHandler<MouseEvent>
    * @param FXMLPath
    *          path to fxml file.
    */
+  public DockNode() {
+    this((Node) null, null, null);
+  }
+  
   public DockNode(String FXMLPath)
   {
     this(FXMLPath, null, null);
@@ -347,14 +351,18 @@ public class DockNode extends VBox implements EventHandler<MouseEvent>
     this.viewController = controller;
 
     dockTitleBar = new DockTitleBar(this);
-    getChildren().addAll(dockTitleBar, contents);
+    getChildren().addAll(dockTitleBar);
 
     if (viewController != null)
     {
       viewController.setDockTitleBar(dockTitleBar);
     }
 
-    VBox.setVgrow(contents, Priority.ALWAYS);
+    if (contents != null) 
+    {
+      getChildren().addAll(contents);
+      VBox.setVgrow(contents, Priority.ALWAYS);
+    }
 
     this.getStyleClass().add("dock-node");
   }
@@ -725,6 +733,25 @@ public class DockNode extends VBox implements EventHandler<MouseEvent>
   {
     this.graphicProperty.setValue(graphic);
   }
+  
+  private ObjectProperty<DockPos> dockPosProperty = new SimpleObjectProperty<DockPos>() {
+    @Override
+    public String getName() {
+      return "dockPos";
+    }
+  };
+  
+  public final ObjectProperty<DockPos> dockPosProperty() {
+    return dockPosProperty;
+  }
+  
+  public final DockPos getDockPos() {
+    return dockPosProperty.get();
+  }
+  
+  public final void setDockPos(DockPos dockPos) {
+    dockPosProperty.set(dockPos);
+  }
 
   /**
    * Boolean property maintaining bidirectional state of the caption title for
@@ -736,7 +763,7 @@ public class DockNode extends VBox implements EventHandler<MouseEvent>
   {
     return titleProperty;
   }
-
+  
   private StringProperty titleProperty =
                                        new SimpleStringProperty("Dock")
                                        {

--- a/src/main/java/org/dockfx/DockPane.java
+++ b/src/main/java/org/dockfx/DockPane.java
@@ -37,7 +37,9 @@ import java.util.logging.Logger;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
+import javafx.beans.Observable;
 import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import javafx.css.PseudoClass;
@@ -343,6 +345,26 @@ public class DockPane extends StackPane
     dockAreaIndicator.getStyleClass().add("dock-area-indicator");
 
     undockedNodes = FXCollections.observableArrayList();
+    
+    final DockPane finalThis = this;
+    
+    getChildren().addListener(new ListChangeListener<Node>() {
+      @Override
+      public void onChanged(Change<? extends Node> c) {
+        while (c.next()) {
+          if (c.wasAdded()) {
+            for (Node node : c.getAddedSubList()) {
+              if (node instanceof DockNode) {
+                getChildren().remove(node);// to prevent redundant child items; the dock function
+                                           // will add the child node back
+                DockNode dockNode = (DockNode) node;
+                dockNode.dock(finalThis, dockNode.getDockPos());
+              }
+            }
+          }
+        }
+      }
+    });
   }
 
   /**
@@ -657,6 +679,17 @@ public class DockPane extends StackPane
    *          The docking position of the node relative to the sibling.
    */
   void dock(Node node, DockPos dockPos)
+  {
+    dock(node, dockPos, root);
+  }
+  
+  public static DockPos dockPos;
+  
+  void add(Node node) {
+    dock(node, DockPos.LEFT, root);
+  }
+  
+  void add(Node node, DockPos dockPos)
   {
     dock(node, dockPos, root);
   }


### PR DESCRIPTION
These changes implement the functionality requested in #9.  Some thought OP was requesting the ability to initialize a DockNode by passing it an fxml file which has already been implemented.  What OP wanted was support for the following:

```
<DockPane fx:id="dockPane">
  <DockNode fx:id="dockNode1" title="Node 1">
    <dockPos>LEFT</dockPos>
    <Label text="Node 1 content"/>
  </DockNode>
  <DockNode fx:id="dockNode2" title="Node 2">
    <dockPos>RIGHT</dockPos>
    <Label text="Node 2 content"/>
  </DockNode>
</DockPane>
```